### PR TITLE
Update vimeo v tag

### DIFF
--- a/tvpage-library/build.gradle
+++ b/tvpage-library/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     api fileTree(include: ['*.jar'], dir: 'libs')
     api 'com.android.support:appcompat-v7:25.3.1'
     api 'com.github.HaarigerHarald:android-youtubeExtractor:v1.7.0'
-    api 'com.github.ed-george:AndroidVimeoExtractor:v1.1.1'
+    api 'com.github.ed-george:AndroidVimeoExtractor:1.1.1'
     //Glide
     api 'com.github.bumptech.glide:glide:3.7.0'
     //Glide transformation


### PR DESCRIPTION
- Vimeo Extractor library has changed there version tagging for releases.  Changed build.gradle to match